### PR TITLE
Fix terminated field initialization

### DIFF
--- a/malactor/src/mal_actor.c
+++ b/malactor/src/mal_actor.c
@@ -83,6 +83,7 @@ mal_actor_t *mal_actor_new(
   self->router = mal_routing_new(self->endpoint, state);
   self->initialize = initialize;
   self->finalize = finalize;
+  self->terminated = false;
 
   self->actor = zactor_new(mal_actor_run, self);
 


### PR DESCRIPTION
Previously, the field was not initialized. So, its value is
a random value. As a consequence, the mal_actor_run can terminate
immediately.

Now, the field is initialized to false, as it shuold be.

PS: this can be avoided by using calloc instead of malloc in
mal_actor_new.