### PR TITLE
Revert declaration of *_private_selftest

### DIFF
--- a/mal/include/mal.h
+++ b/mal/include/mal.h
@@ -438,9 +438,6 @@ void mal_test(bool verbose);
 #include "mal_encoder.h"
 #include "mal_decoder.h"
 
-// Fixes somes compilation issues with recent releases of Zproject.
-void mal_private_selftest(bool verbose);
-
 #ifdef __cplusplus
 }
 #endif

--- a/mal/include/mal.h
+++ b/mal/include/mal.h
@@ -32,24 +32,7 @@
 extern "C" {
 #endif
 
-#include "clog.h"
-
-#include "malattributes.h"
-
-//  MAL API version macros for compile-time API detection
-
-#define MAL_VERSION_MAJOR 1
-#define MAL_VERSION_MINOR 0
-#define MAL_VERSION_PATCH 0
-
-#define MAL_MAKE_VERSION(major, minor, patch) \
-    ((major) * 10000 + (minor) * 100 + (patch))
-#define MAL_VERSION \
-    MAL_MAKE_VERSION(MAL_VERSION_MAJOR, MAL_VERSION_MINOR, MAL_VERSION_PATCH)
-
-extern clog_logger_t mal_logger;
-
-void mal_set_log_level(int level);
+#include <malattributes.h>
 
 #define MAL_AREA_NUMBER 1
 #define MAL_AREA_VERSION 1
@@ -77,42 +60,6 @@ void mal_set_log_level(int level);
 #define MAL_IP_STAGE_PUBSUB_PUBLISH_DEREGISTER 9
 #define MAL_IP_STAGE_PUBSUB_PUBLISH_DEREGISTER_ACK 10
 
-typedef struct _mal_encoder_t mal_encoder_t;
-typedef struct _mal_decoder_t mal_decoder_t;
-
-typedef struct _mal_ctx_t mal_ctx_t;
-typedef struct _mal_message_t mal_message_t;
-typedef struct _mal_poller_t mal_poller_t;
-typedef struct _mal_endpoint_t mal_endpoint_t;
-typedef struct _mal_subscription_t mal_subscription_t;
-typedef struct _mal_entitykey_t mal_entitykey_t;
-typedef struct _mal_entityrequest_t mal_entityrequest_t;
-typedef struct _mal_element_holder_t mal_element_holder_t;
-typedef struct _mal_updateheader_t mal_updateheader_t;
-
-typedef struct _mal_integer_list_t mal_integer_list_t;
-typedef struct _mal_uinteger_list_t mal_uinteger_list_t;
-typedef struct _mal_double_list_t mal_double_list_t;
-typedef struct _mal_float_list_t mal_float_list_t;
-typedef struct _mal_long_list_t mal_long_list_t;
-typedef struct _mal_ulong_list_t mal_ulong_list_t;
-typedef struct _mal_short_list_t mal_short_list_t;
-typedef struct _mal_ushort_list_t mal_ushort_list_t;
-typedef struct _mal_octet_list_t mal_octet_list_t;
-typedef struct _mal_uoctet_list_t mal_uoctet_list_t;
-typedef struct _mal_identifier_list_t mal_identifier_list_t;
-typedef struct _mal_string_list_t mal_string_list_t;
-typedef struct _mal_blob_list_t mal_blob_list_t;
-typedef struct _mal_entityrequest_list_t mal_entityrequest_list_t;
-typedef struct _mal_entitykey_list_t mal_entitykey_list_t;
-typedef struct _mal_updateheader_list_t mal_updateheader_list_t;
-typedef struct _mal_boolean_list_t mal_boolean_list_t;
-typedef struct _mal_time_list_t mal_time_list_t;
-typedef struct _mal_finetime_list_t mal_finetime_list_t;
-typedef struct _mal_duration_list_t mal_duration_list_t;
-typedef struct _mal_uri_list_t mal_uri_list_t;
-typedef struct _mal_subscription_list_t mal_subscription_list_t;
-
 // generated code for enumeration mal_interactiontype
 typedef enum {
   MAL_INTERACTIONTYPE_SEND,
@@ -125,7 +72,6 @@ typedef enum {
 
 // short form for enumeration type mal_interactiontype
 #define MAL_INTERACTIONTYPE_SHORT_FORM 0x1000001000013L
-typedef struct _mal_interactiontype_list_t mal_interactiontype_list_t;
 
 // short form for list of enumeration type mal_interactiontype
 #define MAL_INTERACTIONTYPE_LIST_SHORT_FORM 0x1000001ffffedL
@@ -139,7 +85,6 @@ typedef enum {
 
 // short form for enumeration type mal_sessiontype
 #define MAL_SESSIONTYPE_SHORT_FORM 0x1000001000014L
-typedef struct _mal_sessiontype_list_t mal_sessiontype_list_t;
 
 // short form for list of enumeration type mal_sessiontype
 #define MAL_SESSIONTYPE_LIST_SHORT_FORM 0x1000001ffffecL
@@ -154,7 +99,6 @@ typedef enum {
 
 // short form for enumeration type mal_qoslevel
 #define MAL_QOSLEVEL_SHORT_FORM 0x1000001000015L
-typedef struct _mal_qoslevel_list_t mal_qoslevel_list_t;
 
 // short form for list of enumeration type mal_qoslevel
 #define MAL_QOSLEVEL_LIST_SHORT_FORM 0x1000001ffffebL
@@ -169,7 +113,6 @@ typedef enum {
 
 // short form for enumeration type mal_updatetype
 #define MAL_UPDATETYPE_SHORT_FORM 0x1000001000016L
-typedef struct _mal_updatetype_list_t mal_updatetype_list_t;
 
 // short form for list of enumeration type mal_updatetype
 #define MAL_UPDATETYPE_LIST_SHORT_FORM 0x1000001ffffeaL
@@ -198,62 +141,11 @@ union mal_element_t {
   void *list_value;
 };
 
-/* ***** ***** ***** ***** ***** ***** ***** ***** ***** *****
- * Transport SPI
- * ***** ***** ***** ***** ***** ***** ***** ***** ***** ******/
+#include "mal_library.h"
 
-// Function to be provided by a MAL binding to create a URI
-typedef mal_uri_t *mal_binding_ctx_create_uri_fn(void *mal_binding_ctx, char *id);
+extern clog_logger_t mal_logger;
 
-// Function to be provided by a MAL binding to create an MAL end-point
-typedef void *mal_binding_ctx_create_endpoint_fn(void *mal_binding_ctx, mal_endpoint_t *mal_endpoint);
-
-// Function to be provided by a MAL binding to destroy an MAL end-point
-typedef void mal_binding_ctx_destroy_endpoint_fn(void *mal_binding_ctx, void **endpoint_p);
-
-// Function to be provided by a MAL binding to create a MAL poller
-typedef void *mal_binding_ctx_create_poller_fn(void *mal_binding_ctx, mal_poller_t *mal_poller);
-
-// Function to be provided by a MAL binding to destroy a MAL poller
-typedef void mal_binding_ctx_destroy_poller_fn(void *mal_binding_ctx, void **poller_p);
-
-// Function to be provided by a MAL binding to add an end-point to a MAL poller
-typedef int mal_binding_ctx_poller_add_endpoint_fn(
-    void *mal_binding_ctx,
-    mal_poller_t *mal_poller,
-    mal_endpoint_t *mal_endpoint);
-
-// Function to be provided by a MAL binding to remove an end-point to a MAL poller
-typedef int mal_binding_ctx_poller_del_endpoint_fn(
-    void *mal_binding_ctx,
-    mal_poller_t *mal_poller,
-    mal_endpoint_t *mal_endpoint);
-
-// Function to be provided by a MAL binding to send a message
-typedef int mal_binding_ctx_send_message_fn(
-    void *mal_binding_ctx,
-    mal_endpoint_t *mal_endpoint,
-    mal_message_t *message);
-
-// Function to be provided by a MAL binding to receive a message
-typedef int mal_binding_ctx_recv_message_fn(
-    void *mal_binding_ctx,
-    mal_endpoint_t *mal_endpoint, mal_message_t **message);
-
-typedef int mal_binding_ctx_init_operation_fn(
-    mal_endpoint_t *mal_endpoint, mal_message_t *message, mal_uri_t *uri_to, bool set_tid);
-
-// Function to be provided by a MAL binding to wait on a MAL poller
-typedef int mal_binding_ctx_poller_wait_fn(
-    void *mal_binding_ctx,
-    mal_poller_t *mal_poller, mal_endpoint_t **mal_endpoint, int timeout);
-
-// Function to be provided by a MAL binding to destroy a message
-typedef int mal_binding_ctx_destroy_message_fn(void *mal_binding_ctx, mal_message_t *message);
-
-typedef int mal_binding_ctx_start_fn(void *mal_binding_ctx);
-typedef int mal_binding_ctx_stop_fn(void *mal_binding_ctx);
-typedef int mal_binding_ctx_destroy_fn(void **mal_binding_ctx);
+void mal_set_log_level(int level);
 
 /* ***** ***** ***** ***** ***** ***** ***** ***** ***** *****
  * Encoding API
@@ -351,92 +243,36 @@ int mal_notify_decode_updateheader_list(void *cursor, mal_decoder_t *decoder, ma
 #define MAL_UPDATEHEADER_LIST_SHORT_FORM 0x1000001ffffe6L
 
 // generated code for composite MAL:_:IdBooleanPair
-typedef struct _mal_idbooleanpair_t mal_idbooleanpair_t;
 // short form for composite type MAL:_:IdBooleanPair
 #define MAL_IDBOOLEANPAIR_SHORT_FORM 0x100000100001bL
 
-typedef struct _mal_idbooleanpair_list_t mal_idbooleanpair_list_t;
 // short form for list of composite type MAL:_:IdBooleanPair
 #define MAL_IDBOOLEANPAIR_LIST_SHORT_FORM 0x1000001ffffe5L
 
 // generated code for composite MAL:_:Pair
-typedef struct _mal_pair_t mal_pair_t;
 // short form for composite type MAL:_:Pair
 #define MAL_PAIR_SHORT_FORM 0x100000100001cL
 
-typedef struct _mal_pair_list_t mal_pair_list_t;
 // short form for list of composite type MAL:_:Pair
 #define MAL_PAIR_LIST_SHORT_FORM 0x1000001ffffe4L
 
 // generated code for composite MAL:_:NamedValue
-typedef struct _mal_namedvalue_t mal_namedvalue_t;
 // short form for composite type MAL:_:NamedValue
 #define MAL_NAMEDVALUE_SHORT_FORM 0x100000100001dL
 
-typedef struct _mal_namedvalue_list_t mal_namedvalue_list_t;
 // short form for list of composite type MAL:_:NamedValue
 #define MAL_NAMEDVALUE_LIST_SHORT_FORM 0x1000001ffffe3L
 
 // generated code for composite MAL:_:File
-typedef struct _mal_file_t mal_file_t;
 // short form for composite type MAL:_:File
 #define MAL_FILE_SHORT_FORM 0x100000100001eL
 
-typedef struct _mal_file_list_t mal_file_list_t;
 // short form for list of composite type MAL:_:File
 #define MAL_FILE_LIST_SHORT_FORM 0x1000001ffffe2L
 
 void mal_message_set_log_level(int level);
 
 void mal_test(bool verbose);
-
-//  Public API classes
-#include "mal_ctx.h"
-#include "mal_endpoint.h"
-#include "mal_poller.h"
-#include "mal_integer_list.h"
-#include "mal_uinteger_list.h"
-#include "mal_double_list.h"
-#include "mal_float_list.h"
-#include "mal_long_list.h"
-#include "mal_ulong_list.h"
-#include "mal_short_list.h"
-#include "mal_ushort_list.h"
-#include "mal_octet_list.h"
-#include "mal_uoctet_list.h"
-#include "mal_identifier_list.h"
-#include "mal_blob_list.h"
-#include "mal_entitykey.h"
-#include "mal_string_list.h"
-#include "mal_interactiontype_list.h"
-#include "mal_entityrequest_list.h"
-#include "mal_entitykey_list.h"
-#include "mal_updateheader_list.h"
-#include "mal_subscription_list.h"
-#include "mal_subscription.h"
-#include "mal_entityrequest.h"
-#include "mal_message.h"
-#include "mal_updateheader.h"
-#include "mal_element_holder.h"
-#include "mal_boolean_list.h"
-#include "mal_routing.h"
-#include "mal_time_list.h"
-#include "mal_finetime_list.h"
-#include "mal_duration_list.h"
-#include "mal_uri_list.h"
-#include "mal_file.h"
-#include "mal_file_list.h"
-#include "mal_idbooleanpair.h"
-#include "mal_idbooleanpair_list.h"
-#include "mal_namedvalue.h"
-#include "mal_namedvalue_list.h"
-#include "mal_pair.h"
-#include "mal_pair_list.h"
-#include "mal_sessiontype_list.h"
-#include "mal_updatetype_list.h"
-#include "mal_qoslevel_list.h"
-#include "mal_encoder.h"
-#include "mal_decoder.h"
 
 #ifdef __cplusplus
 }

--- a/mal/include/mal_ctx.h
+++ b/mal/include/mal_ctx.h
@@ -32,6 +32,59 @@
 extern "C" {
 #endif
 
+// Function to be provided by a MAL binding to create a URI
+typedef mal_uri_t *mal_binding_ctx_create_uri_fn(void *mal_binding_ctx, char *id);
+
+// Function to be provided by a MAL binding to create an MAL end-point
+typedef void *mal_binding_ctx_create_endpoint_fn(void *mal_binding_ctx, mal_endpoint_t *mal_endpoint);
+
+// Function to be provided by a MAL binding to destroy an MAL end-point
+typedef void mal_binding_ctx_destroy_endpoint_fn(void *mal_binding_ctx, void **endpoint_p);
+
+// Function to be provided by a MAL binding to create a MAL poller
+typedef void *mal_binding_ctx_create_poller_fn(void *mal_binding_ctx, mal_poller_t *mal_poller);
+
+// Function to be provided by a MAL binding to destroy a MAL poller
+typedef void mal_binding_ctx_destroy_poller_fn(void *mal_binding_ctx, void **poller_p);
+
+// Function to be provided by a MAL binding to add an end-point to a MAL poller
+typedef int mal_binding_ctx_poller_add_endpoint_fn(
+    void *mal_binding_ctx,
+    mal_poller_t *mal_poller,
+    mal_endpoint_t *mal_endpoint);
+
+// Function to be provided by a MAL binding to remove an end-point to a MAL poller
+typedef int mal_binding_ctx_poller_del_endpoint_fn(
+    void *mal_binding_ctx,
+    mal_poller_t *mal_poller,
+    mal_endpoint_t *mal_endpoint);
+
+// Function to be provided by a MAL binding to send a message
+typedef int mal_binding_ctx_send_message_fn(
+    void *mal_binding_ctx,
+    mal_endpoint_t *mal_endpoint,
+    mal_message_t *message);
+
+// Function to be provided by a MAL binding to receive a message
+typedef int mal_binding_ctx_recv_message_fn(
+    void *mal_binding_ctx,
+    mal_endpoint_t *mal_endpoint, mal_message_t **message);
+
+typedef int mal_binding_ctx_init_operation_fn(
+    mal_endpoint_t *mal_endpoint, mal_message_t *message, mal_uri_t *uri_to, bool set_tid);
+
+// Function to be provided by a MAL binding to wait on a MAL poller
+typedef int mal_binding_ctx_poller_wait_fn(
+    void *mal_binding_ctx,
+    mal_poller_t *mal_poller, mal_endpoint_t **mal_endpoint, int timeout);
+
+// Function to be provided by a MAL binding to destroy a message
+typedef int mal_binding_ctx_destroy_message_fn(void *mal_binding_ctx, mal_message_t *message);
+
+typedef int mal_binding_ctx_start_fn(void *mal_binding_ctx);
+typedef int mal_binding_ctx_stop_fn(void *mal_binding_ctx);
+typedef int mal_binding_ctx_destroy_fn(void **mal_binding_ctx);
+
 mal_ctx_t *mal_ctx_new();
 
 void mal_ctx_destroy(mal_ctx_t **self_p);

--- a/malactor/include/malactor.h
+++ b/malactor/include/malactor.h
@@ -53,9 +53,6 @@ void malactor_test(bool verbose);
 //  Public API classes
 #include "mal_actor.h"
 
-// Fixes somes compilation issues with recent releases of Zproject.
-void malactor_private_selftest(bool verbose);
-
 #ifdef __cplusplus
 }
 #endif

--- a/malactor/include/malactor.h
+++ b/malactor/include/malactor.h
@@ -1,18 +1,18 @@
 /*
  * The MIT License (MIT)
- * 
+ *
  * Copyright (c) 2016 CNES
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -32,26 +32,9 @@
 extern "C" {
 #endif
 
-#include "mal.h"
-#include "malzmq.h"
-
-//  MAL/ACTOR API version macros for compile-time API detection
-
-#define MALACTOR_VERSION_MAJOR 1
-#define MALACTOR_VERSION_MINOR 0
-#define MALACTOR_VERSION_PATCH 0
-
-#define MALACTOR_MAKE_VERSION(major, minor, patch) \
-    ((major) * 10000 + (minor) * 100 + (patch))
-#define MALACTOR_VERSION \
-    MALACTOR_MAKE_VERSION(MALACTOR_VERSION_MAJOR, MALACTOR_VERSION_MINOR, MALACTOR_VERSION_PATCH)
-
-typedef struct _mal_actor_t mal_actor_t;
+#include "malactor_library.h"
 
 void malactor_test(bool verbose);
-
-//  Public API classes
-#include "mal_actor.h"
 
 #ifdef __cplusplus
 }

--- a/malattributes/include/malattributes.h
+++ b/malattributes/include/malattributes.h
@@ -127,9 +127,6 @@ typedef double mal_duration_t;
 #include "mal_uri.h"
 #include "mal_attribute.h"
 
-// Fixes somes compilation issues with recent releases of Zproject.
-void malattributes_private_selftest(bool verbose);
-
 #ifdef __cplusplus
 }
 #endif

--- a/malbinary/include/malbinary.h
+++ b/malbinary/include/malbinary.h
@@ -1,18 +1,18 @@
 /*
  * The MIT License (MIT)
- * 
+ *
  * Copyright (c) 2016 CNES
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -32,24 +32,10 @@
 extern "C" {
 #endif
 
-#include "malattributes.h"
-
 #include "mal_encoder.h"
 #include "mal_decoder.h"
 
-//  MALBINARY API version macros for compile-time API detection
-
-#define MALBINARY_VERSION_MAJOR 1
-#define MALBINARY_VERSION_MINOR 0
-#define MALBINARY_VERSION_PATCH 0
-
-#define MALBINARY_MAKE_VERSION(major, minor, patch) \
-    ((major) * 10000 + (minor) * 100 + (patch))
-#define MALBINARY_VERSION \
-    MALBINARY_MAKE_VERSION(MALBINARY_VERSION_MAJOR, MALBINARY_VERSION_MINOR, MALBINARY_VERSION_PATCH)
-
-typedef struct _malbinary_encoder_t malbinary_encoder_t;
-typedef struct _malbinary_decoder_t malbinary_decoder_t;
+#include "malbinary_library.h"
 
 struct _malbinary_cursor_t {
   // Pointer to the first byte of the body, calculated in malbinary_cursor_init from the ptr and
@@ -94,10 +80,6 @@ void malbinary_test(bool verbose);
 #define MILLISECONDS_IN_DAY 86400000L
 #define NANOSECONDS_FROM_CCSDS_TO_UNIX_EPOCH (MILLISECONDS_FROM_CCSDS_TO_UNIX_EPOCH * ONE_MILLION)
 #define NANOSECONDS_IN_DAY (MILLISECONDS_IN_DAY * ONE_MILLION)
-
-//  Public API classes
-#include "malbinary_encoder.h"
-#include "malbinary_decoder.h"
 
 #ifdef __cplusplus
 }

--- a/malbinary/include/malbinary.h
+++ b/malbinary/include/malbinary.h
@@ -99,9 +99,6 @@ void malbinary_test(bool verbose);
 #include "malbinary_encoder.h"
 #include "malbinary_decoder.h"
 
-// Fixes somes compilation issues with recent releases of Zproject.
-void malbinary_private_selftest(bool verbose);
-
 #ifdef __cplusplus
 }
 #endif

--- a/malsplitbinary/include/malsplitbinary.h
+++ b/malsplitbinary/include/malsplitbinary.h
@@ -1,18 +1,18 @@
 /*
  * The MIT License (MIT)
- * 
+ *
  * Copyright (c) 2016 - 2018 CNES
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -32,23 +32,7 @@
 extern "C" {
 #endif
 
-#include "mal.h"
-#include "malattributes.h"
-#include "malbinary.h"
-
-//  MALSPLITBINARY API version macros for compile-time API detection
-
-#define MALSPLITBINARY_VERSION_MAJOR 1
-#define MALSPLITBINARY_VERSION_MINOR 0
-#define MALSPLITBINARY_VERSION_PATCH 0
-
-#define MALSPLITBINARY_MAKE_VERSION(major, minor, patch) \
-    ((major) * 10000 + (minor) * 100 + (patch))
-#define MALSPLITBINARY_VERSION \
-    MALSPLITBINARY_MAKE_VERSION(MALSPLITBINARY_VERSION_MAJOR, MALSPLITBINARY_VERSION_MINOR, MALSPLITBINARY_VERSION_PATCH)
-
-typedef struct _malsplitbinary_encoder_t malsplitbinary_encoder_t;
-typedef struct _malsplitbinary_decoder_t malsplitbinary_decoder_t;
+#include "malsplitbinary_library.h"
 
 struct _malsplitbinary_cursor_t {
   malbinary_cursor_t malbinary_cursor;
@@ -108,10 +92,6 @@ unsigned int malsplitbinary_cursor_get_offset(void *cursor);
 #define MALSPLITBINARY_SMALL_ENUM_SIZE 1
 #define MALSPLITBINARY_MEDIUM_ENUM_SIZE 2
 #define MALSPLITBINARY_LARGE_ENUM_SIZE 4
-
-//  Public API classes
-#include "malsplitbinary_encoder.h"
-#include "malsplitbinary_decoder.h"
 
 void malsplitbinary_test(bool verbose);
 

--- a/malsplitbinary/include/malsplitbinary.h
+++ b/malsplitbinary/include/malsplitbinary.h
@@ -115,9 +115,6 @@ unsigned int malsplitbinary_cursor_get_offset(void *cursor);
 
 void malsplitbinary_test(bool verbose);
 
-// Fixes somes compilation issues with recent releases of Zproject.
-void malsplitbinary_private_selftest(bool verbose);
-
 #ifdef __cplusplus
 }
 #endif

--- a/maltcp/include/maltcp.h
+++ b/maltcp/include/maltcp.h
@@ -1,18 +1,18 @@
 /*
  * The MIT License (MIT)
- * 
+ *
  * Copyright (c) 2016 CNES
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -32,21 +32,7 @@
 extern "C" {
 #endif
 
-#include "mal.h"
-#include "malbinary.h"
-#include "czmq.h"
-#include "zmq.h"
-
-//  MALTCP API version macros for compile-time API detection
-
-#define MALTCP_VERSION_MAJOR 1
-#define MALTCP_VERSION_MINOR 0
-#define MALTCP_VERSION_PATCH 0
-
-#define MALTCP_MAKE_VERSION(major, minor, patch) \
-    ((major) * 10000 + (minor) * 100 + (patch))
-#define MALTCP_VERSION \
-		MALTCP_MAKE_VERSION(MALTCP_VERSION_MAJOR, MALTCP_VERSION_MINOR, MALTCP_VERSION_PATCH)
+#include "maltcp_library.h"
 
 typedef struct _mal_tcp_message_t mal_tcp_message_t;
 
@@ -56,8 +42,24 @@ void maltcp_set_log_level(int level);
 
 #define MALTCP_PROTOCOL_VERSION 1
 
-typedef struct _maltcp_ctx_t maltcp_ctx_t;
-typedef struct _maltcp_header_t maltcp_header_t;
+
+// 'Variable length' offset
+// +1 byte: version + sdu type
+// +2 bytes: service area
+// +2 bytes: service
+// +2 bytes: operation
+// +1 bytes: area version
+// +1 bytes: is error message + qos level + session
+// +8 bytes: transaction id
+// +1 bytes: flags
+// +1 bytes: encoding id
+
+static const int VARIABLE_LENGTH_OFFSET = 19;
+
+// Fixed header length
+// 'Variable length' offset (see above)
+// +4 bytes: variable length
+static const int FIXED_HEADER_LENGTH = 23;
 
 int maltcp_add_message_encoding_length(maltcp_header_t *maltcp_header,
     mal_message_t *message, mal_encoder_t *encoder,
@@ -102,28 +104,6 @@ extern char *maltcp_get_host_from_uri(char *uri);
 extern int maltcp_get_port_from_uri(char *uri);
 
 // END -- URI manipulation functions
-
-// 'Variable length' offset
-// +1 byte: version + sdu type
-// +2 bytes: service area
-// +2 bytes: service
-// +2 bytes: operation
-// +1 bytes: area version
-// +1 bytes: is error message + qos level + session
-// +8 bytes: transaction id
-// +1 bytes: flags
-// +1 bytes: encoding id
-
-static const int VARIABLE_LENGTH_OFFSET = 19;
-
-// Fixed header length
-// 'Variable length' offset (see above)
-// +4 bytes: variable length
-static const int FIXED_HEADER_LENGTH = 23;
-
-//  Public API classes
-#include "maltcp_ctx.h"
-#include "maltcp_header.h"
 
 #ifdef __cplusplus
 }

--- a/maltcp/include/maltcp.h
+++ b/maltcp/include/maltcp.h
@@ -125,9 +125,6 @@ static const int FIXED_HEADER_LENGTH = 23;
 #include "maltcp_ctx.h"
 #include "maltcp_header.h"
 
-// Fixes somes compilation issues with recent releases of Zproject.
-void maltcp_private_selftest(bool verbose);
-
 #ifdef __cplusplus
 }
 #endif

--- a/malzmq/include/malzmq.h
+++ b/malzmq/include/malzmq.h
@@ -103,9 +103,6 @@ extern char *malzmq_get_service_from_uri(char *full_uri);
 #include "malzmq_ctx.h"
 #include "malzmq_header.h"
 
-// Fixes somes compilation issues with recent releases of Zproject.
-void malzmq_private_selftest(bool verbose);
-
 #ifdef __cplusplus
 }
 #endif

--- a/malzmq/include/malzmq.h
+++ b/malzmq/include/malzmq.h
@@ -1,18 +1,18 @@
 /*
  * The MIT License (MIT)
- * 
+ *
  * Copyright (c) 2016 CNES
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -32,43 +32,13 @@
 extern "C" {
 #endif
 
-#include "mal.h"
-#include "malbinary.h"
-#include "czmq.h"
-#include "zmq.h"
-
-//  MALZMQ API version macros for compile-time API detection
-
-#define MALZMQ_VERSION_MAJOR 1
-#define MALZMQ_VERSION_MINOR 0
-#define MALZMQ_VERSION_PATCH 0
-
-#define MALZMQ_MAKE_VERSION(major, minor, patch) \
-    ((major) * 10000 + (minor) * 100 + (patch))
-#define MALZMQ_VERSION \
-		MALZMQ_MAKE_VERSION(MALZMQ_VERSION_MAJOR, MALZMQ_VERSION_MINOR, MALZMQ_VERSION_PATCH)
+#include "malzmq_library.h"
 
 extern clog_logger_t malzmq_logger;
 
 void malzmq_set_log_level(int level);
 
 #define MALZMQ_PROTOCOL_VERSION 1
-
-typedef struct _malzmq_ctx_t malzmq_ctx_t;
-typedef struct _malzmq_header_t malzmq_header_t;
-
-int malzmq_add_message_encoding_length(malzmq_header_t *malzmq_header,
-    mal_message_t *message, mal_encoder_t *encoder,
-    void *cursor);
-
-int malzmq_encode_message(malzmq_header_t *malzmq_header,
-    mal_message_t *message, mal_encoder_t *encoder, void *cursor);
-
-int malzmq_decode_message(malzmq_header_t *malzmq_header,
-    mal_message_t *message, mal_decoder_t *decoder, void *cursor);
-
-int malzmq_decode_uri_to(malzmq_header_t *malzmq_header,
-	mal_decoder_t *decoder, char *bytes, unsigned int length, mal_uri_t **uri_to);
 
 void malzmq_test(bool verbose);
 
@@ -99,9 +69,18 @@ extern char *malzmq_get_service_from_uri(char *full_uri);
 
 // END -- URI manipulation functions
 
-//  Public API classes
-#include "malzmq_ctx.h"
-#include "malzmq_header.h"
+int malzmq_add_message_encoding_length(malzmq_header_t *malzmq_header,
+    mal_message_t *message, mal_encoder_t *encoder,
+    void *cursor);
+
+int malzmq_encode_message(malzmq_header_t *malzmq_header,
+    mal_message_t *message, mal_encoder_t *encoder, void *cursor);
+
+int malzmq_decode_message(malzmq_header_t *malzmq_header,
+    mal_message_t *message, mal_decoder_t *decoder, void *cursor);
+
+int malzmq_decode_uri_to(malzmq_header_t *malzmq_header,
+	mal_decoder_t *decoder, char *bytes, unsigned int length, mal_uri_t **uri_to);
 
 #ifdef __cplusplus
 }

--- a/test/encoding/include/encoding.h
+++ b/test/encoding/include/encoding.h
@@ -1,18 +1,18 @@
 /*
  * The MIT License (MIT)
- * 
+ *
  * Copyright (c) 2016 CNES
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -29,21 +29,9 @@
 extern "C" {
 #endif
 
-#include "mal.h"
-#include "malbinary.h"
-#include "malsplitbinary.h"
-
-#define ENCODING_VERSION_MAJOR 1
-#define ENCODING_VERSION_MINOR 0
-#define ENCODING_VERSION_PATCH 0
-
-#define ENCODING_MAKE_VERSION(major, minor, patch) \
-    ((major) * 10000 + (minor) * 100 + (patch))
-#define ENCODING_VERSION \
-    ENCODING_MAKE_VERSION(ENCODING_VERSION_MAJOR, ENCODING_VERSION_MINOR, ENCODING_VERSION_PATCH)
+#include "encoding_library.h"
 
 void encoding_test(bool verbose);
-void file_encoding_test(bool verbose);
 bool testFixedBinaryEncoding();
 
 #ifdef __cplusplus

--- a/test/encoding/include/encoding.h
+++ b/test/encoding/include/encoding.h
@@ -46,9 +46,6 @@ void encoding_test(bool verbose);
 void file_encoding_test(bool verbose);
 bool testFixedBinaryEncoding();
 
-// Fixes somes compilation issues with recent releases of Zproject.
-void encoding_private_selftest(bool verbose);
-
 #ifdef __cplusplus
 }
 #endif

--- a/test/invoke_app/include/invoke_app.h
+++ b/test/invoke_app/include/invoke_app.h
@@ -1,18 +1,18 @@
 /*
  * The MIT License (MIT)
- * 
+ *
  * Copyright (c) 2016 CNES
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -29,31 +29,9 @@
 extern "C" {
 #endif
 
-#include "mal.h"
-#include "malbinary.h"
-#include "malsplitbinary.h"
-#include "malzmq.h"
-#include "maltcp.h"
-#include "testarea.h"
-#include "malactor.h"
-
-#define INVOKE_APP_VERSION_MAJOR 1
-#define INVOKE_APP_VERSION_MINOR 0
-#define INVOKE_APP_VERSION_PATCH 0
-
-#define INVOKE_APP_MAKE_VERSION(major, minor, patch) \
-    ((major) * 10000 + (minor) * 100 + (patch))
-#define INVOKE_APP_VERSION \
-		INVOKE_APP_MAKE_VERSION(INVOKE_APP_VERSION_MAJOR, INVOKE_APP_VERSION_MINOR, INVOKE_APP_VERSION_PATCH)
-
-typedef struct _invoke_app_myprovider_t invoke_app_myprovider_t;
-typedef struct _invoke_app_myconsumer_t invoke_app_myconsumer_t;
+#include "invoke_app_library.h"
 
 void invoke_app_test(bool verbose);
-
-// Public API classes
-#include "invoke_app_myconsumer.h"
-#include "invoke_app_myprovider.h"
 
 extern mal_actor_t *provider_actor;
 extern mal_actor_t *consumer_actor;

--- a/test/invoke_app/include/invoke_app.h
+++ b/test/invoke_app/include/invoke_app.h
@@ -58,9 +58,6 @@ void invoke_app_test(bool verbose);
 extern mal_actor_t *provider_actor;
 extern mal_actor_t *consumer_actor;
 
-// Fixes somes compilation issues with recent releases of Zproject.
-void invoke_app_private_selftest(bool verbose);
-
 #ifdef __cplusplus
 }
 #endif

--- a/test/malzmq_pubsub_app/include/pubsub_app.h
+++ b/test/malzmq_pubsub_app/include/pubsub_app.h
@@ -1,18 +1,18 @@
 /*
  * The MIT License (MIT)
- * 
+ *
  * Copyright (c) 2016 CNES
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -29,32 +29,11 @@
 extern "C" {
 #endif
 
-#include "mal.h"
-#include "malbinary.h"
-#include "malzmq.h"
-#include "testarea.h"
-#include "malactor.h"
+#include "pubsub_app_library.h"
 
-#define PUBSUB_APP_VERSION_MAJOR 1
-#define PUBSUB_APP_VERSION_MINOR 0
-#define PUBSUB_APP_VERSION_PATCH 0
-
-#define PUBSUB_APP_MAKE_VERSION(major, minor, patch) \
-    ((major) * 10000 + (minor) * 100 + (patch))
-#define PUBSUB_APP_VERSION \
-    PUBSUB_APP_MAKE_VERSION(PUBSUB_APP_VERSION_MAJOR, PUBSUB_APP_VERSION_MINOR, PUBSUB_APP_VERSION_PATCH)
-
-typedef struct _pubsub_app_mypublisher_t pubsub_app_mypublisher_t;
-typedef struct _pubsub_app_mysubscriber_t pubsub_app_mysubscriber_t;
-typedef struct _pubsub_app_broker_t pubsub_app_broker_t;
 typedef struct _pubsub_subscriber_t pubsub_subscriber_t;
 
 void pubsub_app_test(bool verbose);
-
-// Public API classes
-#include "../../malzmq_pubsub_app/include/pubsub_app_mysubscriber.h"
-#include "../../malzmq_pubsub_app/include/pubsub_app_mypublisher.h"
-#include "../../malzmq_pubsub_app/include/pubsub_app_broker.h"
 
 extern mal_actor_t *publisher_actor;
 extern mal_actor_t *subscriber_actor;

--- a/test/malzmq_pubsub_app/include/pubsub_app.h
+++ b/test/malzmq_pubsub_app/include/pubsub_app.h
@@ -60,9 +60,6 @@ extern mal_actor_t *publisher_actor;
 extern mal_actor_t *subscriber_actor;
 extern mal_actor_t *broker_actor;
 
-// Fixes somes compilation issues with recent releases of Zproject.
-void pubsub_app_private_selftest(bool verbose);
-
 #ifdef __cplusplus
 }
 #endif

--- a/test/progress_app/include/progress_app.h
+++ b/test/progress_app/include/progress_app.h
@@ -1,18 +1,18 @@
 /*
  * The MIT License (MIT)
- * 
+ *
  * Copyright (c) 2016 CNES
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -29,31 +29,9 @@
 extern "C" {
 #endif
 
-#include "mal.h"
-#include "malbinary.h"
-#include "malsplitbinary.h"
-#include "malzmq.h"
-#include "maltcp.h"
-#include "testarea.h"
-#include "malactor.h"
-
-#define PROGRESS_APP_VERSION_MAJOR 1
-#define PROGRESS_APP_VERSION_MINOR 0
-#define PROGRESS_APP_VERSION_PATCH 0
-
-#define PROGRESS_APP_MAKE_VERSION(major, minor, patch) \
-    ((major) * 10000 + (minor) * 100 + (patch))
-#define PROGRESS_APP_VERSION \
-		PROGRESS_APP_MAKE_VERSION(PROGRESS_APP_VERSION_MAJOR, PROGRESS_APP_VERSION_MINOR, PROGRESS_APP_VERSION_PATCH)
-
-typedef struct _progress_app_myprovider_t progress_app_myprovider_t;
-typedef struct _progress_app_myconsumer_t progress_app_myconsumer_t;
+#include "progress_app_library.h"
 
 void progress_app_test(bool verbose);
-
-// Public API classes
-#include "progress_app_myconsumer.h"
-#include "progress_app_myprovider.h"
 
 extern mal_actor_t *consumer_actor;
 extern mal_actor_t *provider_actor;

--- a/test/progress_app/include/progress_app.h
+++ b/test/progress_app/include/progress_app.h
@@ -58,9 +58,6 @@ void progress_app_test(bool verbose);
 extern mal_actor_t *consumer_actor;
 extern mal_actor_t *provider_actor;
 
-// Fixes somes compilation issues with recent releases of Zproject.
-void progress_app_private_selftest(bool verbose);
-
 #ifdef __cplusplus
 }
 #endif

--- a/test/progress_consumer/include/progress_consumer.h
+++ b/test/progress_consumer/include/progress_consumer.h
@@ -84,9 +84,6 @@ void progress_consumer_test(bool verbose);
 
 extern mal_actor_t *consumer_actor;
 
-// Fixes somes compilation issues with recent releases of Zproject.
-void progress_consumer_private_selftest(bool verbose);
-
 #ifdef __cplusplus
 }
 #endif

--- a/test/progress_provider/include/progress_provider.h
+++ b/test/progress_provider/include/progress_provider.h
@@ -70,9 +70,6 @@ void progress_provider_test(bool verbose);
 
 extern mal_actor_t *provider_actor;
 
-// Fixes somes compilation issues with recent releases of Zproject.
-void progress_provider_private_selftest(bool verbose);
-
 #ifdef __cplusplus
 }
 #endif

--- a/test/pubsub_app/include/pubsub_app.h
+++ b/test/pubsub_app/include/pubsub_app.h
@@ -62,9 +62,6 @@ extern mal_actor_t *publisher_actor;
 extern mal_actor_t *subscriber_actor;
 extern mal_actor_t *broker_actor;
 
-// Fixes somes compilation issues with recent releases of Zproject.
-void pubsub_app_private_selftest(bool verbose);
-
 #ifdef __cplusplus
 }
 #endif

--- a/test/pubsub_app/include/pubsub_app.h
+++ b/test/pubsub_app/include/pubsub_app.h
@@ -1,18 +1,18 @@
 /*
  * The MIT License (MIT)
- * 
+ *
  * Copyright (c) 2016 CNES
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -29,34 +29,11 @@
 extern "C" {
 #endif
 
-#include "mal.h"
-#include "malbinary.h"
-#include "malsplitbinary.h"
-#include "malzmq.h"
-#include "maltcp.h"
-#include "testarea.h"
-#include "malactor.h"
+#include "pubsub_app_library.h"
 
-#define PUBSUB_APP_VERSION_MAJOR 1
-#define PUBSUB_APP_VERSION_MINOR 0
-#define PUBSUB_APP_VERSION_PATCH 0
-
-#define PUBSUB_APP_MAKE_VERSION(major, minor, patch) \
-    ((major) * 10000 + (minor) * 100 + (patch))
-#define PUBSUB_APP_VERSION \
-    PUBSUB_APP_MAKE_VERSION(PUBSUB_APP_VERSION_MAJOR, PUBSUB_APP_VERSION_MINOR, PUBSUB_APP_VERSION_PATCH)
-
-typedef struct _pubsub_app_mypublisher_t pubsub_app_mypublisher_t;
-typedef struct _pubsub_app_mysubscriber_t pubsub_app_mysubscriber_t;
-typedef struct _pubsub_app_broker_t pubsub_app_broker_t;
 typedef struct _pubsub_subscriber_t pubsub_subscriber_t;
 
 void pubsub_app_test(bool verbose);
-
-// Public API classes
-#include "pubsub_app_mysubscriber.h"
-#include "pubsub_app_mypublisher.h"
-#include "pubsub_app_broker.h"
 
 extern mal_actor_t *publisher_actor;
 extern mal_actor_t *subscriber_actor;

--- a/test/request_app/include/request_app.h
+++ b/test/request_app/include/request_app.h
@@ -58,9 +58,6 @@ void request_app_test(bool verbose);
 extern mal_actor_t *provider_actor;
 extern mal_actor_t *consumer_actor;
 
-// Fixes somes compilation issues with recent releases of Zproject.
-void request_app_private_selftest(bool verbose);
-
 #ifdef __cplusplus
 }
 #endif

--- a/test/request_app/include/request_app.h
+++ b/test/request_app/include/request_app.h
@@ -1,18 +1,18 @@
 /*
  * The MIT License (MIT)
- * 
+ *
  * Copyright (c) 2016 CNES
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -29,31 +29,9 @@
 extern "C" {
 #endif
 
-#include "mal.h"
-#include "malbinary.h"
-#include "malsplitbinary.h"
-#include "malzmq.h"
-#include "maltcp.h"
-#include "testarea.h"
-#include "malactor.h"
-
-#define REQUEST_APP_VERSION_MAJOR 1
-#define REQUEST_APP_VERSION_MINOR 0
-#define REQUEST_APP_VERSION_PATCH 0
-
-#define REQUEST_APP_MAKE_VERSION(major, minor, patch) \
-    ((major) * 10000 + (minor) * 100 + (patch))
-#define REQUEST_APP_VERSION \
-		REQUEST_APP_MAKE_VERSION(REQUEST_APP_VERSION_MAJOR, REQUEST_APP_VERSION_MINOR, REQUEST_APP_VERSION_PATCH)
-
-typedef struct _request_app_myprovider_t request_app_myprovider_t;
-typedef struct _request_app_myconsumer_t request_app_myconsumer_t;
+#include "request_app_library.h"
 
 void request_app_test(bool verbose);
-
-// Public API classes
-#include "request_app_myconsumer.h"
-#include "request_app_myprovider.h"
 
 extern mal_actor_t *provider_actor;
 extern mal_actor_t *consumer_actor;

--- a/test/send_app/include/send_app.h
+++ b/test/send_app/include/send_app.h
@@ -58,9 +58,6 @@ void send_app_test(bool verbose);
 extern mal_actor_t *consumer_actor;
 extern mal_actor_t *provider_actor;
 
-// Fixes somes compilation issues with recent releases of Zproject.
-void send_app_private_selftest(bool verbose);
-
 #ifdef __cplusplus
 }
 #endif

--- a/test/send_app/include/send_app.h
+++ b/test/send_app/include/send_app.h
@@ -1,18 +1,18 @@
 /*
  * The MIT License (MIT)
- * 
+ *
  * Copyright (c) 2016 CNES
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -29,31 +29,9 @@
 extern "C" {
 #endif
 
-#include "mal.h"
-#include "malbinary.h"
-#include "malsplitbinary.h"
-#include "malzmq.h"
-#include "maltcp.h"
-#include "testarea.h"
-#include "malactor.h"
-
-#define SEND_APP_VERSION_MAJOR 1
-#define SEND_APP_VERSION_MINOR 0
-#define SEND_APP_VERSION_PATCH 0
-
-#define SEND_APP_MAKE_VERSION(major, minor, patch) \
-    ((major) * 10000 + (minor) * 100 + (patch))
-#define SEND_APP_VERSION \
-    SEND_APP_MAKE_VERSION(SEND_APP_VERSION_MAJOR, SEND_APP_VERSION_MINOR, SEND_APP_VERSION_PATCH)
-
-typedef struct _send_app_myprovider_t send_app_myprovider_t;
-typedef struct _send_app_myconsumer_t send_app_myconsumer_t;
+#include "send_app_library.h"
 
 void send_app_test(bool verbose);
-
-// Public API classes
-#include "send_app_myconsumer.h"
-#include "send_app_myprovider.h"
 
 extern mal_actor_t *consumer_actor;
 extern mal_actor_t *provider_actor;

--- a/test/simple_app/include/simple_app.h
+++ b/test/simple_app/include/simple_app.h
@@ -58,9 +58,6 @@ void simple_app_test(bool verbose);
 extern zactor_t *provider_actor;
 extern zactor_t *consumer_actor;
 
-// Fixes somes compilation issues with recent releases of Zproject.
-void simple_app_private_selftest(bool verbose);
-
 #ifdef __cplusplus
 }
 #endif

--- a/test/simple_app/include/simple_app.h
+++ b/test/simple_app/include/simple_app.h
@@ -1,18 +1,18 @@
 /*
  * The MIT License (MIT)
- * 
+ *
  * Copyright (c) 2016 CNES
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -29,31 +29,9 @@
 extern "C" {
 #endif
 
-#include "mal.h"
-#include "malbinary.h"
-#include "malsplitbinary.h"
-#include "malzmq.h"
-#include "maltcp.h"
-#include "testarea.h"
-#include "malactor.h"
-
-#define SIMPLE_APP_VERSION_MAJOR 1
-#define SIMPLE_APP_VERSION_MINOR 0
-#define SIMPLE_APP_VERSION_PATCH 0
-
-#define SIMPLE_APP_MAKE_VERSION(major, minor, patch) \
-    ((major) * 10000 + (minor) * 100 + (patch))
-#define SIMPLE_APP_VERSION \
-    SIMPLE_APP_MAKE_VERSION(SIMPLE_APP_VERSION_MAJOR, SIMPLE_APP_VERSION_MINOR, SIMPLE_APP_VERSION_PATCH)
-
-typedef struct _simple_app_myprovider_t simple_app_myprovider_t;
-typedef struct _simple_app_myconsumer_t simple_app_myconsumer_t;
+#include "simple_app_library.h"
 
 void simple_app_test(bool verbose);
-
-// Public API classes
-#include "simple_app_myconsumer.h"
-#include "simple_app_myprovider.h"
 
 extern zactor_t *provider_actor;
 extern zactor_t *consumer_actor;

--- a/test/submit_app/include/submit_app.h
+++ b/test/submit_app/include/submit_app.h
@@ -58,9 +58,6 @@ void submit_app_test(bool verbose);
 extern mal_actor_t *provider_actor;
 extern mal_actor_t *consumer_actor;
 
-// Fixes somes compilation issues with recent releases of Zproject.
-void submit_app_private_selftest(bool verbose);
-
 #ifdef __cplusplus
 }
 #endif

--- a/test/submit_app/include/submit_app.h
+++ b/test/submit_app/include/submit_app.h
@@ -1,18 +1,18 @@
 /*
  * The MIT License (MIT)
- * 
+ *
  * Copyright (c) 2016 CNES
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -29,31 +29,9 @@
 extern "C" {
 #endif
 
-#include "mal.h"
-#include "malbinary.h"
-#include "malsplitbinary.h"
-#include "malzmq.h"
-#include "maltcp.h"
-#include "testarea.h"
-#include "malactor.h"
-
-#define SUBMIT_APP_VERSION_MAJOR 1
-#define SUBMIT_APP_VERSION_MINOR 0
-#define SUBMIT_APP_VERSION_PATCH 0
-
-#define SUBMIT_APP_MAKE_VERSION(major, minor, patch) \
-    ((major) * 10000 + (minor) * 100 + (patch))
-#define SUBMIT_APP_VERSION \
-		SUBMIT_APP_MAKE_VERSION(SUBMIT_APP_VERSION_MAJOR, SUBMIT_APP_VERSION_MINOR, SUBMIT_APP_VERSION_PATCH)
-
-typedef struct _submit_app_myprovider_t submit_app_myprovider_t;
-typedef struct _submit_app_myconsumer_t submit_app_myconsumer_t;
+#include "submit_app_library.h"
 
 void submit_app_test(bool verbose);
-
-// Public API classes
-#include "submit_app_myconsumer.h"
-#include "submit_app_myprovider.h"
 
 extern mal_actor_t *provider_actor;
 extern mal_actor_t *consumer_actor;

--- a/test/testarea/include/testarea.h
+++ b/test/testarea/include/testarea.h
@@ -235,9 +235,6 @@ void testarea_test(bool verbose);
 #include "testarea_testservice_testfinalcompositeb.h"
 #include "testarea_testservice_testfinalcompositeb_list.h"
 
-// Fixes somes compilation issues with recent releases of Zproject.
-void testarea_private_selftest(bool verbose);
-
 #ifdef __cplusplus
 }
 #endif // __cplusplus

--- a/test/testarea/include/testarea.h
+++ b/test/testarea/include/testarea.h
@@ -1,18 +1,18 @@
 /*
  * The MIT License (MIT)
- * 
+ *
  * Copyright (c) 2016 - 2017 CNES
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -32,12 +32,6 @@ extern "C" {
 #define TEST_SPLIT (false)
 #define TEST_TCP (false)
 
-#include "mal.h"
-#include "malbinary.h"
-#include "malsplitbinary.h"
-
-int testarea_malbinary_decode_mal_element(mal_decoder_t * decoder, void * cursor, mal_element_holder_t * element_holder);
-
 // standard area identifiers
 #define TESTAREA_AREA_NUMBER 200
 #define TESTAREA_AREA_VERSION 1
@@ -51,7 +45,6 @@ typedef enum {
 
 // short form for enumeration type testarea_testenumeration
 #define TESTAREA_TESTENUMERATION_SHORT_FORM 0xc8000001000002L
-typedef struct _testarea_testenumeration_list_t testarea_testenumeration_list_t;
 
 // short form for list of enumeration type testarea_testenumeration
 #define TESTAREA_TESTENUMERATION_LIST_SHORT_FORM 0xc8000001fffffeL
@@ -60,54 +53,43 @@ typedef struct _testarea_testenumeration_list_t testarea_testenumeration_list_t;
 #define TESTAREA_TESTSERVICE_SERVICE_NUMBER 1
 
 // generated code for composite TestArea:TestService:TestComposite
-typedef struct _testarea_testservice_testcomposite_t testarea_testservice_testcomposite_t;
-
 // short form for composite type TestArea:TestService:TestComposite
 #define TESTAREA_TESTSERVICE_TESTCOMPOSITE_SHORT_FORM 0xc8000101000001L
-typedef struct _testarea_testservice_testcomposite_list_t testarea_testservice_testcomposite_list_t;
 
 // short form for list of composite type TestArea:TestService:TestComposite
 #define TESTAREA_TESTSERVICE_TESTCOMPOSITE_LIST_SHORT_FORM 0xc8000101ffffffL
 
 // generated code for composite TestArea:TestService:TestFullComposite
-typedef struct _testarea_testservice_testfullcomposite_t testarea_testservice_testfullcomposite_t;
-
 // short form for composite type TestArea:TestService:TestFullComposite
 #define TESTAREA_TESTSERVICE_TESTFULLCOMPOSITE_SHORT_FORM 0xc8000101000002L
-typedef struct _testarea_testservice_testfullcomposite_list_t testarea_testservice_testfullcomposite_list_t;
 
 // short form for list of composite type TestArea:TestService:TestFullComposite
 #define TESTAREA_TESTSERVICE_TESTFULLCOMPOSITE_LIST_SHORT_FORM 0xc8000101fffffeL
 
 // generated code for composite TestArea:TestService:TestUpdate
-typedef struct _testarea_testservice_testupdate_t testarea_testservice_testupdate_t;
-
 // short form for composite type TestArea:TestService:TestUpdate
 #define TESTAREA_TESTSERVICE_TESTUPDATE_SHORT_FORM 0xc8000101000003L
-typedef struct _testarea_testservice_testupdate_list_t testarea_testservice_testupdate_list_t;
 
 // short form for list of composite type TestArea:TestService:TestUpdate
 #define TESTAREA_TESTSERVICE_TESTUPDATE_LIST_SHORT_FORM 0xc8000101fffffdL
 
 // generated code for composite TestArea:TestService:TestFinalCompositeA
-typedef struct _testarea_testservice_testfinalcompositea_t testarea_testservice_testfinalcompositea_t;
-
 // short form for composite type TestArea:TestService:TestFinalCompositeA
 #define TESTAREA_TESTSERVICE_TESTFINALCOMPOSITEA_SHORT_FORM 0xc8000101000004L
-typedef struct _testarea_testservice_testfinalcompositea_list_t testarea_testservice_testfinalcompositea_list_t;
 
 // short form for list of composite type TestArea:TestService:TestFinalCompositeA
 #define TESTAREA_TESTSERVICE_TESTFINALCOMPOSITEA_LIST_SHORT_FORM 0xc8000101fffffcL
 
 // generated code for composite TestArea:TestService:TestFinalCompositeB
-typedef struct _testarea_testservice_testfinalcompositeb_t testarea_testservice_testfinalcompositeb_t;
-
 // short form for composite type TestArea:TestService:TestFinalCompositeB
 #define TESTAREA_TESTSERVICE_TESTFINALCOMPOSITEB_SHORT_FORM 0xc8000101000005L
-typedef struct _testarea_testservice_testfinalcompositeb_list_t testarea_testservice_testfinalcompositeb_list_t;
 
 // short form for list of composite type TestArea:TestService:TestFinalCompositeB
 #define TESTAREA_TESTSERVICE_TESTFINALCOMPOSITEB_LIST_SHORT_FORM 0xc8000101fffffbL
+
+#include "testarea_library.h"
+
+int testarea_malbinary_decode_mal_element(mal_decoder_t * decoder, void * cursor, mal_element_holder_t * element_holder);
 
 // include required areas definitions
 #include "com.h"
@@ -222,18 +204,6 @@ int testarea_testservice_testcrossref_send_decode_0(void * cursor, mal_decoder_t
 
 // test function
 void testarea_test(bool verbose);
-
-#include "testarea_testenumeration_list.h"
-#include "testarea_testservice_testcomposite.h"
-#include "testarea_testservice_testcomposite_list.h"
-#include "testarea_testservice_testfullcomposite.h"
-#include "testarea_testservice_testfullcomposite_list.h"
-#include "testarea_testservice_testupdate.h"
-#include "testarea_testservice_testupdate_list.h"
-#include "testarea_testservice_testfinalcompositea.h"
-#include "testarea_testservice_testfinalcompositea_list.h"
-#include "testarea_testservice_testfinalcompositeb.h"
-#include "testarea_testservice_testfinalcompositeb_list.h"
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This function is generated and its signature is subject to change.
Previously: *_private_selftest(boolean)
Current: *_private_selftest(boolean, char*)

Compilation warning is better than compilation error.

Potential fix of this issue is to use `<module>_library.h` headers. But this introduce collisions with other declarations in `<module>.h`.