### PR TITLE
Introduce distclean target

### DIFF
--- a/bin/genmake
+++ b/bin/genmake
@@ -31,6 +31,10 @@ echo "### Generate MAL/C from $MAL_HOME to $MAL_LOCAL"
 genmake_clean() {
   echo "=== clean : $PWD"
   make clean
+}
+genmake_distclean() {
+  echo "=== distclean : $PWD"
+  make clean
   rm -f aclocal.m4 configure.ac libtool Makefile.in
   rm -f autogen.sh config.log *.cmake
   rm -f config.status Makefile version.sh ci_build.sh
@@ -82,6 +86,9 @@ genmake() {
     clean)
       genmake_clean
       ;;
+    distclean)
+      genmake_distclean
+      ;;
     gen)
       genmake_gen
       ;;
@@ -95,7 +102,7 @@ genmake() {
       genmake_check
       ;;
     *)
-      echo "Usage: $0 {all|clean|gen|compile|install|check}"
+      echo "Usage: $0 {all|clean|distclean|gen|compile|install|check}"
       exit 1
   esac
 }

--- a/genmakeall
+++ b/genmakeall
@@ -27,7 +27,7 @@ fi
 
 # Should remove $MAL_LOCAL -> print a message
 if  [ "$#" -ne "0" ]; then
-  if [ $1 == "clean" ]; then
+  if [ $1 == "distclean" ]; then
     echo ""
     echo "!! May be you should clean $MAL_LOCAL target directory !!"
     echo ""


### PR DESCRIPTION
Allow to select between clean and distclean.
The clean target allow to quicly refire a compilation.