### PR TITLE
Fix peer uri

### DIFF
--- a/maltcp/src/maltcp_ctx.c
+++ b/maltcp/src/maltcp_ctx.c
@@ -796,8 +796,9 @@ int maltcp_ctx_recv_message(void *self, mal_endpoint_t *mal_endpoint, mal_messag
     } else if (strncmp(uri_from, MALTCP_URI, sizeof MALTCP_URI -1) != 0) {
       if (uri_from[0] == '/')
         uri_from += 1;
-      mal_uri_t *uri = (mal_uri_t *) malloc(strlen(peer_uri) + strlen(uri_from) +1);
+      mal_uri_t *uri = (mal_uri_t *) malloc(strlen(peer_uri) + strlen(uri_from) +2);
       strcpy(uri, peer_uri);
+      strcat(uri, "/");
       strcat(uri, uri_from);
       mal_message_set_uri_from(*message, uri);
       mal_message_set_free_uri_from(*message, (1==1));

--- a/test/submit_app/src/submit_app_myprovider.c
+++ b/test/submit_app/src/submit_app_myprovider.c
@@ -195,7 +195,7 @@ int submit_app_myprovider_testarea_testservice_testsubmit(
 
   printf("AF: submit_app_myprovider: handler send ACK\n");
   rc = testarea_testservice_testsubmit_submit_ack(mal_endpoint, message, result_message, (0 != 0));
-  printf("AF: submit_app_myprovider: handler ACK sent\n");
+  printf("AF: submit_app_myprovider: handler ACK sent: %d\n", rc);
 
   printf("destroy parameter_0\n");
   testarea_testservice_testcomposite_destroy(&parameter_0);


### PR DESCRIPTION
When this separator is missing, it seems that tests are failing (unable to open connections).